### PR TITLE
Refactor: Use Lombok to remove boilerplate code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,12 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jdbc-h2</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.30</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/com/fitconnect/dto/AppointmentDTO.java
+++ b/src/main/java/com/fitconnect/dto/AppointmentDTO.java
@@ -3,7 +3,9 @@ package com.fitconnect.dto;
 import com.fitconnect.entity.Appointment;
 import com.fitconnect.entity.AppointmentStatus;
 import java.time.LocalDateTime;
+import lombok.Data;
 
+@Data
 public class AppointmentDTO {
     public Long id;
     public Long serviceRequestId;

--- a/src/main/java/com/fitconnect/dto/ClientSelectProfessionalRequestDTO.java
+++ b/src/main/java/com/fitconnect/dto/ClientSelectProfessionalRequestDTO.java
@@ -1,12 +1,10 @@
 package com.fitconnect.dto;
 
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
 public class ClientSelectProfessionalRequestDTO {
     private Long professionalId;
-
-    public Long getProfessionalId() {
-        return professionalId;
-    }
-    public void setProfessionalId(Long professionalId) {
-        this.professionalId = professionalId;
-    }
 }

--- a/src/main/java/com/fitconnect/dto/LLMStructuredMatchResponse.java
+++ b/src/main/java/com/fitconnect/dto/LLMStructuredMatchResponse.java
@@ -1,26 +1,20 @@
 package com.fitconnect.dto;
 
 import java.util.List;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Data
+@NoArgsConstructor
 public class LLMStructuredMatchResponse {
     public String rankingRationale;
     public List<RankedProfessional> rankedProfessionals;
 
+    @Data
+    @NoArgsConstructor
     public static class RankedProfessional {
         public Long professionalId;
         public String individualRationale;
         public int rank;
-
-        // Getters & Setters for Jackson
-        public Long getProfessionalId() { return professionalId; }
-        public void setProfessionalId(Long professionalId) { this.professionalId = professionalId; }
-        public String getIndividualRationale() { return individualRationale; }
-        public void setIndividualRationale(String individualRationale) { this.individualRationale = individualRationale; }
-        public int getRank() { return rank; }
-        public void setRank(int rank) { this.rank = rank; }
     }
-    public String getRankingRationale() { return rankingRationale; }
-    public void setRankingRationale(String rankingRationale) { this.rankingRationale = rankingRationale; }
-    public List<RankedProfessional> getRankedProfessionals() { return rankedProfessionals; }
-    public void setRankedProfessionals(List<RankedProfessional> rankedProfessionals) { this.rankedProfessionals = rankedProfessionals; }
 }

--- a/src/main/java/com/fitconnect/dto/LoginRequest.java
+++ b/src/main/java/com/fitconnect/dto/LoginRequest.java
@@ -1,11 +1,11 @@
 package com.fitconnect.dto;
 
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
 public class LoginRequest {
     private String email;
     private String password;
-
-    public String getEmail() { return email; }
-    public void setEmail(String email) { this.email = email; }
-    public String getPassword() { return password; }
-    public void setPassword(String password) { this.password = password; }
 }

--- a/src/main/java/com/fitconnect/dto/LoginResponse.java
+++ b/src/main/java/com/fitconnect/dto/LoginResponse.java
@@ -1,5 +1,10 @@
 package com.fitconnect.dto;
 
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
 public class LoginResponse {
     private String token;
     private String email;
@@ -13,13 +18,4 @@ public class LoginResponse {
         this.email = email;
         this.role = role;
     }
-
-    public String getToken() { return token; }
-    public void setToken(String token) { this.token = token; }
-    public String getEmail() { return email; }
-    public void setEmail(String email) { this.email = email; }
-    public String getRole() { return role; }
-    public void setRole(String role) { this.role = role; }
-    public Long getUserId() { return userId; }
-    public void setUserId(Long userId) { this.userId = userId; }
 }

--- a/src/main/java/com/fitconnect/dto/MatchResponseDTO.java
+++ b/src/main/java/com/fitconnect/dto/MatchResponseDTO.java
@@ -1,14 +1,14 @@
 package com.fitconnect.dto;
 
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class MatchResponseDTO {
     public String rankingCriteria;
     public List<MatchedProfessionalDTO> matchedProfessionals;
-
-    public MatchResponseDTO(String rankingCriteria, List<MatchedProfessionalDTO> matchedProfessionals) {
-        this.rankingCriteria = rankingCriteria;
-        this.matchedProfessionals = matchedProfessionals;
-    }
-    public MatchResponseDTO() {}
 }

--- a/src/main/java/com/fitconnect/dto/MatchedProfessionalDTO.java
+++ b/src/main/java/com/fitconnect/dto/MatchedProfessionalDTO.java
@@ -3,7 +3,11 @@ package com.fitconnect.dto;
 import com.fitconnect.entity.Professional;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Data
+@NoArgsConstructor
 public class MatchedProfessionalDTO {
     public Long id;
     public String name;
@@ -24,5 +28,4 @@ public class MatchedProfessionalDTO {
             this.skills = pro.skills.stream().map(skill -> skill.name).collect(Collectors.toList());
         }
     }
-    public MatchedProfessionalDTO() {}
 }

--- a/src/main/java/com/fitconnect/dto/ProfessionalFullProfileDTO.java
+++ b/src/main/java/com/fitconnect/dto/ProfessionalFullProfileDTO.java
@@ -4,11 +4,15 @@ import com.fitconnect.entity.Professional;
 import com.fitconnect.entity.ProfessionalDocument;
 import com.fitconnect.entity.ProfileStatus;
 import com.fitconnect.entity.Skill;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Data
+@NoArgsConstructor
 public class ProfessionalFullProfileDTO {
     public Long id;
     public String name;
@@ -26,6 +30,8 @@ public class ProfessionalFullProfileDTO {
     public List<String> skills; // Names of skills
     public List<DocumentInfoDTO> documents;
 
+    @Data
+    @NoArgsConstructor
     public static class DocumentInfoDTO {
         public Long id;
         public String fileName;

--- a/src/main/java/com/fitconnect/dto/ProfessionalProfileUpdateDTO.java
+++ b/src/main/java/com/fitconnect/dto/ProfessionalProfileUpdateDTO.java
@@ -1,8 +1,12 @@
 package com.fitconnect.dto;
 
 import java.util.Map;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 // Contains fields a professional can update for their own profile.
+@Data
+@NoArgsConstructor
 public class ProfessionalProfileUpdateDTO {
     // Not all fields are updatable directly, e.g., email (usually part of auth identity), status.
     // Name and phone number might be updatable via a general User update DTO if separated.
@@ -18,24 +22,4 @@ public class ProfessionalProfileUpdateDTO {
     private Map<String, String> socialMediaLinks;
     // Password update should be a separate endpoint/flow.
     // Document updates (add/delete) would also be separate if complex.
-
-    // Getters and Setters
-    public String getName() { return name; }
-    public void setName(String name) { this.name = name; }
-    public String getPhoneNumber() { return phoneNumber; }
-    public void setPhoneNumber(String phoneNumber) { this.phoneNumber = phoneNumber; }
-    public String getProfession() { return profession; }
-    public void setProfession(String profession) { this.profession = profession; }
-    public String getAddress() { return address; }
-    public void setAddress(String address) { this.address = address; }
-    public String getPostalCode() { return postalCode; }
-    public void setPostalCode(String postalCode) { this.postalCode = postalCode; }
-    public Integer getYearsOfExperience() { return yearsOfExperience; }
-    public void setYearsOfExperience(Integer yearsOfExperience) { this.yearsOfExperience = yearsOfExperience; }
-    public String getQualifications() { return qualifications; }
-    public void setQualifications(String qualifications) { this.qualifications = qualifications; }
-    public String getAboutYou() { return aboutYou; }
-    public void setAboutYou(String aboutYou) { this.aboutYou = aboutYou; }
-    public Map<String, String> getSocialMediaLinks() { return socialMediaLinks; }
-    public void setSocialMediaLinks(Map<String, String> socialMediaLinks) { this.socialMediaLinks = socialMediaLinks; }
 }

--- a/src/main/java/com/fitconnect/dto/ProfessionalPublicProfileDTO.java
+++ b/src/main/java/com/fitconnect/dto/ProfessionalPublicProfileDTO.java
@@ -5,7 +5,11 @@ import com.fitconnect.entity.Skill;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Data
+@NoArgsConstructor
 public class ProfessionalPublicProfileDTO {
     public Long id;
     public String name;

--- a/src/main/java/com/fitconnect/dto/ProfessionalRegisterRequest.java
+++ b/src/main/java/com/fitconnect/dto/ProfessionalRegisterRequest.java
@@ -4,11 +4,15 @@ import com.fitconnect.entity.UserRole;
 import org.jboss.resteasy.reactive.PartType;
 import org.jboss.resteasy.reactive.RestForm;
 import org.jboss.resteasy.reactive.multipart.FileUpload;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import jakarta.ws.rs.core.MediaType;
 import java.util.List;
 import java.util.Map;
 
+@Data
+@NoArgsConstructor
 public class ProfessionalRegisterRequest {
 
     @RestForm("name")

--- a/src/main/java/com/fitconnect/dto/ProfileVerificationRequest.java
+++ b/src/main/java/com/fitconnect/dto/ProfileVerificationRequest.java
@@ -1,15 +1,11 @@
 package com.fitconnect.dto;
 
 import com.fitconnect.entity.ProfileStatus;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Data
+@NoArgsConstructor
 public class ProfileVerificationRequest {
     public ProfileStatus newStatus;
-
-    public ProfileStatus getNewStatus() {
-        return newStatus;
-    }
-
-    public void setNewStatus(ProfileStatus newStatus) {
-        this.newStatus = newStatus;
-    }
 }

--- a/src/main/java/com/fitconnect/dto/RegisterRequest.java
+++ b/src/main/java/com/fitconnect/dto/RegisterRequest.java
@@ -1,7 +1,12 @@
 package com.fitconnect.dto;
 
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 // Using a single DTO for registration for now, can be specialized
 // for Professional and Client if fields diverge significantly beyond User fields.
+@Data
+@NoArgsConstructor
 public class RegisterRequest {
     private String name;
     private String email;
@@ -9,13 +14,4 @@ public class RegisterRequest {
     private String phoneNumber;
     // Add professional-specific fields if this DTO is used for professional registration directly
     // For now, assuming separate more detailed DTOs or service logic will handle this.
-
-    public String getName() { return name; }
-    public void setName(String name) { this.name = name; }
-    public String getEmail() { return email; }
-    public void setEmail(String email) { this.email = email; }
-    public String getPassword() { return password; }
-    public void setPassword(String password) { this.password = password; }
-    public String getPhoneNumber() { return phoneNumber; }
-    public void setPhoneNumber(String phoneNumber) { this.phoneNumber = phoneNumber; }
 }

--- a/src/main/java/com/fitconnect/dto/ServiceRequestInputDTO.java
+++ b/src/main/java/com/fitconnect/dto/ServiceRequestInputDTO.java
@@ -1,33 +1,13 @@
 package com.fitconnect.dto;
 
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 // DTO for creating a new service request
+@Data
+@NoArgsConstructor
 public class ServiceRequestInputDTO {
     private String category;
     private String serviceDescription;
     private String budget; // e.g., "50-100", "negotiable"
-
-    // Getters and Setters
-    public String getCategory() {
-        return category;
-    }
-
-    public void setCategory(String category) {
-        this.category = category;
-    }
-
-    public String getServiceDescription() {
-        return serviceDescription;
-    }
-
-    public void setServiceDescription(String serviceDescription) {
-        this.serviceDescription = serviceDescription;
-    }
-
-    public String getBudget() {
-        return budget;
-    }
-
-    public void setBudget(String budget) {
-        this.budget = budget;
-    }
 }

--- a/src/main/java/com/fitconnect/entity/Appointment.java
+++ b/src/main/java/com/fitconnect/entity/Appointment.java
@@ -3,9 +3,15 @@ package com.fitconnect.entity;
 import jakarta.persistence.*;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "appointments")
+@Getter
+@Setter
+@NoArgsConstructor
 public class Appointment extends PanacheEntityBase {
 
     @Id
@@ -36,70 +42,5 @@ public class Appointment extends PanacheEntityBase {
     protected void onCreate() {
         createdAt = LocalDateTime.now();
         status = AppointmentStatus.REQUESTED; // Initial status when client picks a professional
-    }
-
-    // Getters and Setters
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public Professional getProfessional() {
-        return professional;
-    }
-
-    public void setProfessional(Professional professional) {
-        this.professional = professional;
-    }
-
-    public Client getClient() {
-        return client;
-    }
-
-    public void setClient(Client client) {
-        this.client = client;
-    }
-
-    public ServiceRequest getServiceRequest() {
-        return serviceRequest;
-    }
-
-    public void setServiceRequest(ServiceRequest serviceRequest) {
-        this.serviceRequest = serviceRequest;
-    }
-
-    public LocalDateTime getAppointmentDateTime() {
-        return appointmentDateTime;
-    }
-
-    public void setAppointmentDateTime(LocalDateTime appointmentDateTime) {
-        this.appointmentDateTime = appointmentDateTime;
-    }
-
-    public String getCommunicationDetails() {
-        return communicationDetails;
-    }
-
-    public void setCommunicationDetails(String communicationDetails) {
-        this.communicationDetails = communicationDetails;
-    }
-
-    public AppointmentStatus getStatus() {
-        return status;
-    }
-
-    public void setStatus(AppointmentStatus status) {
-        this.status = status;
-    }
-
-    public LocalDateTime getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(LocalDateTime createdAt) {
-        this.createdAt = createdAt;
     }
 }

--- a/src/main/java/com/fitconnect/entity/Client.java
+++ b/src/main/java/com/fitconnect/entity/Client.java
@@ -4,10 +4,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import java.util.List;
 import jakarta.persistence.OneToMany;
+import lombok.Getter;
+import lombok.Setter;
 
 
 @Entity
 @Table(name = "clients")
+@Getter
+@Setter
 public class Client extends User {
 
     // Client-specific attributes can be added here if any in the future

--- a/src/main/java/com/fitconnect/entity/Professional.java
+++ b/src/main/java/com/fitconnect/entity/Professional.java
@@ -3,9 +3,13 @@ package com.fitconnect.entity;
 import jakarta.persistence.*;
 import java.util.List;
 import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
 
 @Entity
 @Table(name = "professionals")
+@Getter
+@Setter
 public class Professional extends User {
 
     public String profession;

--- a/src/main/java/com/fitconnect/entity/ProfessionalDocument.java
+++ b/src/main/java/com/fitconnect/entity/ProfessionalDocument.java
@@ -2,9 +2,15 @@ package com.fitconnect.entity;
 
 import jakarta.persistence.*;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "professional_documents")
+@Getter
+@Setter
+@NoArgsConstructor
 public class ProfessionalDocument extends PanacheEntityBase {
 
     @Id
@@ -18,45 +24,4 @@ public class ProfessionalDocument extends PanacheEntityBase {
     public String fileName;
     public String fileType; // e.g., application/pdf, image/jpeg
     public String storagePath; // Path where the file is stored
-
-    // Getters and Setters
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public Professional getProfessional() {
-        return professional;
-    }
-
-    public void setProfessional(Professional professional) {
-        this.professional = professional;
-    }
-
-    public String getFileName() {
-        return fileName;
-    }
-
-    public void setFileName(String fileName) {
-        this.fileName = fileName;
-    }
-
-    public String getFileType() {
-        return fileType;
-    }
-
-    public void setFileType(String fileType) {
-        this.fileType = fileType;
-    }
-
-    public String getStoragePath() {
-        return storagePath;
-    }
-
-    public void setStoragePath(String storagePath) {
-        this.storagePath = storagePath;
-    }
 }

--- a/src/main/java/com/fitconnect/entity/ServiceRequest.java
+++ b/src/main/java/com/fitconnect/entity/ServiceRequest.java
@@ -3,9 +3,15 @@ package com.fitconnect.entity;
 import jakarta.persistence.*;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "service_requests")
+@Getter
+@Setter
+@NoArgsConstructor
 public class ServiceRequest extends PanacheEntityBase {
 
     @Id
@@ -36,70 +42,5 @@ public class ServiceRequest extends PanacheEntityBase {
     @PreUpdate
     protected void onUpdate() {
         updatedAt = LocalDateTime.now();
-    }
-
-    // Getters and Setters
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public Client getClient() {
-        return client;
-    }
-
-    public void setClient(Client client) {
-        this.client = client;
-    }
-
-    public String getCategory() {
-        return category;
-    }
-
-    public void setCategory(String category) {
-        this.category = category;
-    }
-
-    public String getServiceDescription() {
-        return serviceDescription;
-    }
-
-    public void setServiceDescription(String serviceDescription) {
-        this.serviceDescription = serviceDescription;
-    }
-
-    public String getBudget() {
-        return budget;
-    }
-
-    public void setBudget(String budget) {
-        this.budget = budget;
-    }
-
-    public ServiceRequestStatus getStatus() {
-        return status;
-    }
-
-    public void setStatus(ServiceRequestStatus status) {
-        this.status = status;
-    }
-
-    public LocalDateTime getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(LocalDateTime createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    public LocalDateTime getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(LocalDateTime updatedAt) {
-        this.updatedAt = updatedAt;
     }
 }

--- a/src/main/java/com/fitconnect/entity/Skill.java
+++ b/src/main/java/com/fitconnect/entity/Skill.java
@@ -3,9 +3,19 @@ package com.fitconnect.entity;
 import jakarta.persistence.*;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 @Entity
 @Table(name = "skills")
+@Getter
+@Setter
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = false, exclude = "professionals") // callSuper = false as PanacheEntityBase has no fields for equals/hashCode by default
+@ToString(exclude = "professionals")
 public class Skill extends PanacheEntityBase {
 
     @Id
@@ -17,29 +27,4 @@ public class Skill extends PanacheEntityBase {
 
     @ManyToMany(mappedBy = "skills", fetch = FetchType.LAZY)
     public List<Professional> professionals;
-
-    // Getters and Setters
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public List<Professional> getProfessionals() {
-        return professionals;
-    }
-
-    public void setProfessionals(List<Professional> professionals) {
-        this.professionals = professionals;
-    }
 }

--- a/src/main/java/com/fitconnect/entity/User.java
+++ b/src/main/java/com/fitconnect/entity/User.java
@@ -2,10 +2,16 @@ package com.fitconnect.entity;
 
 import jakarta.persistence.*;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "users")
 @Inheritance(strategy = InheritanceType.JOINED)
+@Getter
+@Setter
+@NoArgsConstructor
 public class User extends PanacheEntityBase {
 
     @Id
@@ -24,53 +30,4 @@ public class User extends PanacheEntityBase {
 
     public String name; // Common for both, though professional might have a more formal 'fullName'
     public String phoneNumber;
-
-    // Getters and Setters
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
-    public UserRole getRole() {
-        return role;
-    }
-
-    public void setRole(UserRole role) {
-        this.role = role;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getPhoneNumber() {
-        return phoneNumber;
-    }
-
-    public void setPhoneNumber(String phoneNumber) {
-        this.phoneNumber = phoneNumber;
-    }
 }


### PR DESCRIPTION
I replaced manual getters, setters, and basic constructors with Lombok annotations in DTO and Entity classes.

- I added the `org.projectlombok:lombok` dependency to `pom.xml`.
- I refactored classes in `com.fitconnect.dto` to use `@Data`, `@NoArgsConstructor`, etc.
- I refactored classes in `com.fitconnect.entity` to use `@Getter`, `@Setter`, `@NoArgsConstructor`, etc., ensuring JPA compatibility and preserving relationship integrity.

This change reduces boilerplate code and improves maintainability.