### PR TITLE
Fix: Add storagePath to ProfessionalDocument entity

### DIFF
--- a/src/main/java/com/fitconnect/entity/ProfessionalDocument.java
+++ b/src/main/java/com/fitconnect/entity/ProfessionalDocument.java
@@ -24,6 +24,7 @@ public class ProfessionalDocument extends PanacheEntityBase {
 
     private String fileName;
     private String fileType; // e.g., application/pdf, image/jpeg
+    private String storagePath;
 
     @JsonIgnore
     @Lob // For large binary data
@@ -72,5 +73,13 @@ public class ProfessionalDocument extends PanacheEntityBase {
 
     public void setFileContent(byte[] fileContent) {
         this.fileContent = fileContent;
+    }
+
+    public String getStoragePath() {
+        return storagePath;
+    }
+
+    public void setStoragePath(String storagePath) {
+        this.storagePath = storagePath;
     }
 }

--- a/src/test/java/com/fitconnect/entity/ProfessionalDocumentTest.java
+++ b/src/test/java/com/fitconnect/entity/ProfessionalDocumentTest.java
@@ -1,0 +1,15 @@
+package com.fitconnect.entity;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ProfessionalDocumentTest {
+
+    @Test
+    public void testStoragePathGetterSetter() {
+        ProfessionalDocument document = new ProfessionalDocument();
+        String expectedStoragePath = "/test/path/to/document.pdf";
+        document.setStoragePath(expectedStoragePath);
+        assertEquals(expectedStoragePath, document.getStoragePath());
+    }
+}


### PR DESCRIPTION
The ProfessionalService was attempting to set a 'storagePath' on the ProfessionalDocument entity, but this field and its accessors were missing.

I've added the following to `ProfessionalDocument.java`:
- A private String field `storagePath`.
- Public getter `getStoragePath()` and setter `setStoragePath(String path)` methods.

I've also added a unit test (`ProfessionalDocumentTest.java`) to verify that the new getter and setter for `storagePath` function correctly.

This resolves the `java.lang.NoSuchMethodError: 'void com.fitconnect.entity.ProfessionalDocument.setStoragePath(java.lang.String)'` occurring during professional registration.