### PR TITLE
feat: Redirect professionals to verification page until screening is …

### DIFF
--- a/src/main/java/com/fitconnect/dto/LoginResponse.java
+++ b/src/main/java/com/fitconnect/dto/LoginResponse.java
@@ -10,12 +10,14 @@ public class LoginResponse {
     private String email;
     private String role; // e.g. "CLIENT", "PROFESSIONAL"
     private Long userId;
+    private String profileStatus;
 
 
-    public LoginResponse(String token, Long userId, String email, String role) {
+    public LoginResponse(String token, Long userId, String email, String role, String profileStatus) {
         this.token = token;
         this.userId = userId;
         this.email = email;
         this.role = role;
+        this.profileStatus = profileStatus;
     }
 }

--- a/src/main/webui/src/components/ProtectedRoute.js
+++ b/src/main/webui/src/components/ProtectedRoute.js
@@ -18,6 +18,31 @@ const ProtectedRoute = ({ children, allowedRoles }) => {
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
+  // New logic for professional profile status
+  if (currentUser && currentUser.role === 'PROFESSIONAL') {
+    const currentPath = location.pathname;
+    const profileStatus = currentUser.profileStatus;
+
+    if (profileStatus === 'PENDING_VERIFICATION') {
+      if (currentPath !== '/professional-profile-verification') {
+        return <Navigate to="/professional-profile-verification" replace />;
+      }
+      // If PENDING and on verification page, proceed to role check (which should allow if role is PROFESSIONAL)
+    } else if (profileStatus === 'VERIFIED') {
+      if (currentPath === '/professional-profile-verification') {
+        return <Navigate to="/professional-dashboard" replace />;
+      }
+      // If VERIFIED and not on verification page, proceed to role check.
+    } else { // REJECTED, null, or other unexpected statuses
+      if (currentPath !== '/professional-profile-verification') {
+        return <Navigate to="/professional-profile-verification" replace />;
+      }
+      // If status is REJECTED/null etc. and on verification page, allow (page might show status).
+      // Then proceed to role check.
+    }
+  }
+
+  // Existing role check
   if (allowedRoles && allowedRoles.length > 0 && (!currentUser || !allowedRoles.includes(currentUser.role))) {
     // User is logged in, but their role is not allowed for this route.
     // Redirect to a 'not authorized' page or home page. For now, login.

--- a/src/main/webui/src/context/AuthContext.js
+++ b/src/main/webui/src/context/AuthContext.js
@@ -38,18 +38,28 @@ export const AuthProvider = ({ children }) => {
             const data = await apiClient(endpoint, 'POST', { email, password });
             if (data.token) { // Ensure token
                 storeAuthToken(data.token);
-                var user = {"email": data.email, "role": data.role, "userId": data.userId};
-                storeUserInfo(user); // user should be { id, email, role, name (optional) }
+                // Add profileStatus to the user object
+                var user = {"email": data.email, "role": data.role, "userId": data.userId, "profileStatus": data.profileStatus};
+                storeUserInfo(user);
                 setToken(data.token);
-                setCurrentUser(user);
+                setCurrentUser(user); // This will now include profileStatus
 
-                // Navigate based on role
+                // Navigate based on role and profileStatus
                 if (user.role === 'PROFESSIONAL') {
-                    navigate('/professional-dashboard');
+                    if (user.profileStatus === 'PENDING_VERIFICATION') {
+                        navigate('/professional-profile-verification');
+                    } else if (user.profileStatus === 'VERIFIED') {
+                        navigate('/professional-dashboard');
+                    } else {
+                        // Fallback for PROFESSIONAL if status is unexpected (e.g., REJECTED or null/undefined)
+                        // Redirect to login or a generic error page, or verification page as a safe default
+                        navigate('/professional-profile-verification');
+                        // Or consider navigate('/login'); if REJECTED means they shouldn't access anything
+                    }
                 } else if (user.role === 'CLIENT') {
                     navigate('/customer-request');
                 } else {
-                    navigate('/'); // Fallback navigation
+                    navigate('/'); // Fallback navigation for other roles or if role is undefined
                 }
                 return user;
             } else {


### PR DESCRIPTION
…complete

This commit implements changes to the professional user workflow post-signup and on subsequent logins. Professionals are now redirected to a dedicated verification page if their screening process is not yet complete (i.e., profileStatus is PENDING_VERIFICATION).

Key changes:

Backend:
- Modified `LoginResponse.java` to include `profileStatus`.
- Updated `AuthService.java` to populate `profileStatus` in the `LoginResponse` for professional users. The status is fetched from the `Professional` entity.

Frontend:
- Updated `AuthContext.js` to store and manage `profileStatus` as part of the `currentUser` object.
- Modified navigation logic in `AuthContext.js`'s `login` function:
    - Professionals with `PENDING_VERIFICATION` status are redirected to `/professional-profile-verification`.
    - Professionals with `VERIFIED` status are redirected to `/professional-dashboard`.
    - Other statuses (e.g., `REJECTED`, or if status is undefined) default to the verification page.
- Updated `ProtectedRoute.js` to enforce access restrictions:
    - If a professional's `profileStatus` is `PENDING_VERIFICATION`, they are confined to the `/professional-profile-verification` page. Attempts to access other protected professional routes result in a redirect to the verification page.
    - If `profileStatus` is `VERIFIED`, they are redirected to the dashboard if they attempt to access the verification page.
- Verified that `ProfessionalProfileVerificationPage.js` is suitable for displaying status information to users awaiting verification.

This ensures that professionals cannot access the main dashboard features until their screening process is marked as complete (VERIFIED), aligning with the specified requirements. Client user experience remains unaffected.